### PR TITLE
Add Gitea API client

### DIFF
--- a/src/gitea/api/client.ts
+++ b/src/gitea/api/client.ts
@@ -1,0 +1,27 @@
+import fetch from "node-fetch";
+import { GITEA_API_URL } from "./config";
+
+export type GiteaClient = {
+  request<T = unknown>(path: string, options?: RequestInit): Promise<T>;
+};
+
+export function createGiteaClient(token: string): GiteaClient {
+  return {
+    async request(path, options = {}) {
+      const url = path.startsWith("http") ? path : `${GITEA_API_URL}${path}`;
+      const res = await fetch(url, {
+        ...options,
+        headers: {
+          ...(options.headers || {}),
+          Authorization: `token ${token}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Gitea request failed: ${res.status} ${res.statusText}`,
+        );
+      }
+      return (await res.json()) as T;
+    },
+  };
+}

--- a/src/gitea/api/config.ts
+++ b/src/gitea/api/config.ts
@@ -1,0 +1,4 @@
+export const GITEA_API_URL =
+  process.env.GITEA_API_URL || "https://gitea.com/api/v1";
+export const GITEA_SERVER_URL =
+  process.env.GITEA_SERVER_URL || "https://gitea.com";


### PR DESCRIPTION
## Summary
- add Gitea API client wrapper with token auth
- add Gitea API URL configuration

## Testing
- `bun install`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683fc60294448320810cb5def41be80c