### PR TITLE
Add Gitea operations and types

### DIFF
--- a/src/gitea/operations/branch.ts
+++ b/src/gitea/operations/branch.ts
@@ -1,0 +1,77 @@
+// Branch setup operations for Gitea
+import { $ } from "bun";
+import type { GiteaClient } from "../api/client";
+import type { ParsedGiteaContext } from "../context";
+import type { GiteaPullRequest, GiteaRepository } from "../types";
+
+export type BranchInfo = {
+  baseBranch: string;
+  claudeBranch?: string;
+  currentBranch: string;
+};
+
+/**
+ * Setup the working branch for a Gitea repository. For open pull requests the
+ * PR branch is checked out. For issues or closed PRs a new branch is created
+ * from the configured base branch or repository default branch.
+ */
+export async function setupBranch(
+  client: GiteaClient,
+  context: ParsedGiteaContext,
+): Promise<BranchInfo> {
+  const { owner, repo } = context.repository;
+  const index = context.entityNumber;
+  const baseBranchInput = context.inputs.baseBranch;
+
+  // When running on a pull request, check its state
+  if (context.isPR) {
+    const pr = await client.request<GiteaPullRequest>(
+      `/repos/${owner}/${repo}/pulls/${index}`,
+    );
+
+    if (pr.state.toLowerCase() === "open") {
+      const branchName = pr.head.ref;
+      await $`git fetch origin --depth=20 ${branchName}`;
+      await $`git checkout ${branchName}`;
+      return { baseBranch: pr.base.ref, currentBranch: branchName };
+    }
+  }
+
+  // Determine base branch when creating a new one
+  let sourceBranch = baseBranchInput;
+  if (!sourceBranch) {
+    const repoInfo = await client.request<GiteaRepository>(
+      `/repos/${owner}/${repo}`,
+    );
+    sourceBranch = repoInfo.default_branch;
+  }
+
+  const entityType = context.isPR ? "pr" : "issue";
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:-]/g, "")
+    .replace(/\.\d{3}Z/, "")
+    .split("T")
+    .join("_");
+  const newBranch = `claude/${entityType}-${index}-${timestamp}`;
+
+  // Create branch via API using the chosen source branch
+  await client.request(`/repos/${owner}/${repo}/branches`, {
+    method: "POST",
+    body: JSON.stringify({
+      new_branch_name: newBranch,
+      old_branch_name: sourceBranch,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  // Checkout the new branch locally
+  await $`git fetch origin --depth=1 ${newBranch}`;
+  await $`git checkout ${newBranch}`;
+
+  return {
+    baseBranch: sourceBranch,
+    claudeBranch: newBranch,
+    currentBranch: newBranch,
+  };
+}

--- a/src/gitea/operations/comments/common.ts
+++ b/src/gitea/operations/comments/common.ts
@@ -1,0 +1,29 @@
+import { GITEA_SERVER_URL } from "../../api/config";
+
+export const SPINNER_HTML =
+  '<img src="https://github.com/user-attachments/assets/5ac382c7-e004-429b-8e35-7feb3e8f9c6f" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />';
+
+export function createJobRunLink(
+  owner: string,
+  repo: string,
+  runId: string,
+): string {
+  const jobRunUrl = `${GITEA_SERVER_URL}/${owner}/${repo}/actions/runs/${runId}`;
+  return `[View job run](${jobRunUrl})`;
+}
+
+export function createBranchLink(
+  owner: string,
+  repo: string,
+  branchName: string,
+): string {
+  const branchUrl = `${GITEA_SERVER_URL}/${owner}/${repo}/tree/${branchName}`;
+  return `\n[View branch](${branchUrl})`;
+}
+
+export function createCommentBody(
+  jobRunLink: string,
+  branchLink: string = "",
+): string {
+  return `Claude Code is working… ${SPINNER_HTML}\n\nI'll analyze this and get back to you.\n\n${jobRunLink}${branchLink}`;
+}

--- a/src/gitea/operations/comments/create-initial.ts
+++ b/src/gitea/operations/comments/create-initial.ts
@@ -1,0 +1,27 @@
+import { appendFileSync } from "fs";
+import type { GiteaClient } from "../../api/client";
+import { createJobRunLink, createCommentBody } from "./common";
+import type { ParsedGiteaContext } from "../../context";
+
+export async function createInitialComment(
+  client: GiteaClient,
+  context: ParsedGiteaContext,
+) {
+  const { owner, repo } = context.repository;
+  const jobRunLink = createJobRunLink(owner, repo, context.runId);
+  const body = createCommentBody(jobRunLink);
+
+  const response = await client.request<{ id: number }>(
+    `/repos/${owner}/${repo}/issues/${context.entityNumber}/comments`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  const githubOutput = process.env.GITHUB_OUTPUT!;
+  appendFileSync(githubOutput, `claude_comment_id=${response.id}\n`);
+  console.log(`✅ Created initial comment with ID: ${response.id}`);
+  return response.id;
+}

--- a/src/gitea/operations/comments/update-with-branch.ts
+++ b/src/gitea/operations/comments/update-with-branch.ts
@@ -1,0 +1,29 @@
+import type { GiteaClient } from "../../api/client";
+import {
+  createJobRunLink,
+  createBranchLink,
+  createCommentBody,
+} from "./common";
+import type { ParsedGiteaContext } from "../../context";
+
+export async function updateTrackingComment(
+  client: GiteaClient,
+  context: ParsedGiteaContext,
+  commentId: number,
+  branch?: string,
+) {
+  const { owner, repo } = context.repository;
+  const jobRunLink = createJobRunLink(owner, repo, context.runId);
+  let branchLink = "";
+  if (branch && !context.isPR) {
+    branchLink = createBranchLink(owner, repo, branch);
+  }
+  const body = createCommentBody(jobRunLink, branchLink);
+
+  await client.request(`/repos/${owner}/${repo}/issues/comments/${commentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body }),
+  });
+  console.log(`✅ Updated comment ${commentId} with branch link`);
+}

--- a/src/gitea/types.ts
+++ b/src/gitea/types.ts
@@ -1,0 +1,39 @@
+// Basic types for Gitea API responses
+
+export type GiteaUser = {
+  login: string;
+};
+
+export type GiteaRepoPermission = {
+  permission: string;
+  role_name?: string;
+  user?: GiteaUser;
+};
+
+export type GiteaRepository = {
+  default_branch: string;
+};
+
+export type GiteaPullRequest = {
+  number: number;
+  state: string;
+  title: string;
+  body: string;
+  head: { ref: string };
+  base: { ref: string };
+};
+
+export type GiteaIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body: string;
+  user?: GiteaUser;
+};
+
+export type GiteaComment = {
+  id: number;
+  body: string;
+  user?: GiteaUser;
+  html_url?: string;
+};

--- a/src/gitea/validation/permissions.ts
+++ b/src/gitea/validation/permissions.ts
@@ -1,0 +1,30 @@
+import * as core from "@actions/core";
+import type { GiteaClient } from "../api/client";
+import type { ParsedGiteaContext } from "../context";
+import type { GiteaRepoPermission } from "../types";
+
+export async function checkWritePermissions(
+  client: GiteaClient,
+  context: ParsedGiteaContext,
+): Promise<boolean> {
+  const { owner, repo } = context.repository;
+  const username = context.actor;
+
+  try {
+    core.info(`Checking permissions for actor: ${username}`);
+    const perm = await client.request<GiteaRepoPermission>(
+      `/repos/${owner}/${repo}/collaborators/${username}/permission`,
+    );
+    const level = perm.permission;
+    core.info(`Permission level retrieved: ${level}`);
+    if (level === "write" || level === "admin") {
+      core.info(`Actor has write access: ${level}`);
+      return true;
+    }
+    core.warning(`Actor has insufficient permissions: ${level}`);
+    return false;
+  } catch (error) {
+    core.error(`Failed to check permissions: ${error}`);
+    throw new Error(`Failed to check permissions for ${username}: ${error}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add Gitea branch setup helpers
- support comment creation and update on Gitea
- check write permissions via Gitea API
- define Gitea API response types

## Testing
- `npm run format:check`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683fca9636a48320818ed218edd1d9e4