### PR TITLE
Add gitea MCP server inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,24 @@ jobs:
 
 ## Inputs
 
-| Input                 | Description                                                                                                          | Required | Default   |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `anthropic_api_key`   | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                           | No\*     | -         |
-| `direct_prompt`       | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                | No       | -         |
-| `timeout_minutes`     | Timeout in minutes for execution                                                                                     | No       | `30`      |
-| `github_token`        | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
-| `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -         |
-| `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -         |
-| `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
-| `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |
-| `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""        |
-| `disallowed_tools`    | Tools that Claude should never use                                                                                   | No       | ""        |
-| `custom_instructions` | Additional custom instructions to include in the prompt for Claude                                                   | No       | ""        |
-| `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
-| `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
+| Input                 | Description                                                                                                          | Required | Default             |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| `anthropic_api_key`   | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                           | No\*     | -                   |
+| `direct_prompt`       | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                | No       | -                   |
+| `timeout_minutes`     | Timeout in minutes for execution                                                                                     | No       | `30`                |
+| `github_token`        | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -                   |
+| `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -                   |
+| `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -                   |
+| `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`             |
+| `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`             |
+| `use_gitea`           | Enable the gitea MCP server                                                                                          | No       | `false`             |
+| `gitea_host`          | Custom Gitea host for the gitea MCP server                                                                           | No       | `https://gitea.com` |
+| `gitea_token`         | Gitea personal access token for the gitea MCP server                                                                 | No       | -                   |
+| `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""                  |
+| `disallowed_tools`    | Tools that Claude should never use                                                                                   | No       | ""                  |
+| `custom_instructions` | Additional custom instructions to include in the prompt for Claude                                                   | No       | ""                  |
+| `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -                   |
+| `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude`           |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,17 @@ inputs:
     required: false
     default: "false"
 
+  use_gitea:
+    description: "Enable the gitea MCP server"
+    required: false
+    default: "false"
+  gitea_host:
+    description: "Custom Gitea host for the gitea MCP server"
+    required: false
+  gitea_token:
+    description: "Gitea personal access token for the gitea MCP server"
+    required: false
+
   timeout_minutes:
     description: "Timeout in minutes for execution"
     required: false

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -7,37 +7,75 @@ export async function prepareMcpConfig(
   branch: string,
 ): Promise<string> {
   try {
-    const mcpConfig = {
-      mcpServers: {
-        github: {
-          command: "docker",
-          args: [
-            "run",
-            "-i",
-            "--rm",
-            "-e",
-            "GITHUB_PERSONAL_ACCESS_TOKEN",
-            "ghcr.io/anthropics/github-mcp-server:sha-7382253",
-          ],
-          env: {
-            GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,
-          },
-        },
-        github_file_ops: {
-          command: "bun",
-          args: [
-            "run",
-            `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-file-ops-server.ts`,
-          ],
-          env: {
-            GITHUB_TOKEN: githubToken,
-            REPO_OWNER: owner,
-            REPO_NAME: repo,
-            BRANCH_NAME: branch,
-            REPO_DIR: process.env.GITHUB_WORKSPACE || process.cwd(),
-          },
+    const useGiteaInput = core.getBooleanInput("use_gitea", {
+      required: false,
+    });
+    const useGiteaEnv = process.env.USE_GITEA === "true";
+    const giteaHostInput = core.getInput("gitea_host", { required: false });
+    const giteaHostEnv = process.env.GITEA_HOST || process.env.GITEA_SERVER_URL;
+    const giteaHost = giteaHostInput || giteaHostEnv;
+    const giteaTokenInput = core.getInput("gitea_token", { required: false });
+    const giteaTokenEnv = process.env.GITEA_ACCESS_TOKEN;
+    const giteaToken = giteaTokenInput || giteaTokenEnv || "";
+
+    const mcpServers: Record<string, unknown> = {
+      github: {
+        command: "docker",
+        args: [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "ghcr.io/anthropics/github-mcp-server:sha-7382253",
+        ],
+        env: {
+          GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,
         },
       },
+      github_file_ops: {
+        command: "bun",
+        args: [
+          "run",
+          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-file-ops-server.ts`,
+        ],
+        env: {
+          GITHUB_TOKEN: githubToken,
+          REPO_OWNER: owner,
+          REPO_NAME: repo,
+          BRANCH_NAME: branch,
+          REPO_DIR: process.env.GITHUB_WORKSPACE || process.cwd(),
+        },
+      },
+    };
+
+    if (useGiteaInput || useGiteaEnv) {
+      const giteaApiUrl =
+        process.env.GITEA_API_URL ||
+        (giteaHost ? `${giteaHost.replace(/\/$/, "")}/api/v1` : undefined);
+
+      mcpServers.gitea = {
+        command: "docker",
+        args: [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "GITEA_ACCESS_TOKEN",
+          "docker.gitea.com/gitea-mcp-server",
+        ],
+        env: {
+          GITEA_ACCESS_TOKEN: giteaToken,
+          ...(giteaHost
+            ? { GITEA_HOST: giteaHost, GITEA_SERVER_URL: giteaHost }
+            : {}),
+          ...(giteaApiUrl ? { GITEA_API_URL: giteaApiUrl } : {}),
+        },
+      };
+    }
+
+    const mcpConfig = {
+      mcpServers,
     };
 
     return JSON.stringify(mcpConfig, null, 2);


### PR DESCRIPTION
## Summary
- add `gitea_token` input and wire it into MCP config
- support `use_gitea` and `gitea_host` inputs in action
- document new inputs in README

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run format:check --silent`


------
https://chatgpt.com/codex/tasks/task_e_68406ca4c7048320bb8e16e034b52cc7