### PR TITLE
Add Gitea environment inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ jobs:
 | `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -                   |
 | `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`             |
 | `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`             |
-| `use_gitea`           | Enable the gitea MCP server                                                                                          | No       | `false`             |
+| `use_gitea`           | Enable the gitea MCP server. `use_gitea: true` switches the action to Gitea mode                                     | No       | `false`             |
 | `gitea_host`          | Custom Gitea host for the gitea MCP server                                                                           | No       | `https://gitea.com` |
+| `gitea_api_url`       | Custom API endpoint for the gitea MCP server                                                                         | No       | -                   |
+| `gitea_server_url`    | Custom server URL for the gitea MCP server                                                                           | No       | -                   |
 | `gitea_token`         | Gitea personal access token for the gitea MCP server                                                                 | No       | -                   |
 | `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""                  |
 | `disallowed_tools`    | Tools that Claude should never use                                                                                   | No       | ""                  |

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,12 @@ inputs:
   gitea_host:
     description: "Custom Gitea host for the gitea MCP server"
     required: false
+  gitea_api_url:
+    description: "Custom API endpoint for the gitea MCP server"
+    required: false
+  gitea_server_url:
+    description: "Custom server URL for the gitea MCP server"
+    required: false
   gitea_token:
     description: "Gitea personal access token for the gitea MCP server"
     required: false
@@ -110,6 +116,10 @@ runs:
         OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         PLATFORM: ${{ inputs.platform }}
+        USE_GITEA: ${{ inputs.use_gitea }}
+        GITEA_TOKEN: ${{ inputs.gitea_token }}
+        GITEA_API_URL: ${{ inputs.gitea_api_url }}
+        GITEA_SERVER_URL: ${{ inputs.gitea_server_url }}
 
     - name: Run Claude Code
       id: claude-code
@@ -173,6 +183,10 @@ runs:
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
         PLATFORM: ${{ inputs.platform }}
+        USE_GITEA: ${{ inputs.use_gitea }}
+        GITEA_TOKEN: ${{ inputs.gitea_token }}
+        GITEA_API_URL: ${{ inputs.gitea_api_url }}
+        GITEA_SERVER_URL: ${{ inputs.gitea_server_url }}
 
     - name: Display Claude Code Report
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.claude-code.outputs.execution_file != ''


### PR DESCRIPTION
## Summary
- add gitea API and server URL inputs
- pass Gitea values to prepare and update steps
- document use_gitea switch in README

## Testing
- `bun run format:check`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_684295402478832086fa4f9642de5536